### PR TITLE
Fixed README "Try for free here" invalid link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This project contains the following modules:
 - Cases (todo)
 - Opportunity (todo)
 
-## Try for free [here](https://bottlecrm.com/)
+## Try for free [here](https://bottlecrm.io/)
 
 ## Installation Guide
 


### PR DESCRIPTION
Updated "here" link to point to the current https://bottlecrm.io site.